### PR TITLE
Add ability to delete group notification by its id

### DIFF
--- a/src/controllers/notification.controller.js
+++ b/src/controllers/notification.controller.js
@@ -1,4 +1,5 @@
 const { db } = require("../utils/db");
+
 exports.fetchNotifications = async (req, res, next) => {
   try {
     const currentUser = res.locals.user;
@@ -48,6 +49,42 @@ exports.clearNotifications = async (req, res, next) => {
     return res.status(200).json({
       type: "success",
       message: "Clear all notifications",
+      data: null,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.deleteNotificationGroup = async (req, res, next) => {
+  try {
+    const currentUser = res.locals.user;
+    const groupId = req.params.groupId;
+
+    // Look for the notification by id and type of GROUP
+    const foundGroup = await db.notifications.findFirst({
+      where: {
+        fromUserId: currentUser.id,
+        id: groupId,
+        type: "GROUP",
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    // Delete the group if present in the DB
+    if (foundGroup != null) {
+      await db.notifications.delete({
+        where: {
+          id: foundGroup.id,
+        },
+      });
+    }
+
+    return res.status(200).json({
+      type: "success",
+      message: "Delete notification group",
       data: null,
     });
   } catch (error) {

--- a/src/routes/notification.route.js
+++ b/src/routes/notification.route.js
@@ -1,12 +1,14 @@
 const { Router } = require("express");
 const checkAuth = require("../middlewares/auth.middleware");
 const {
-  fetchNotifications,
   clearNotifications,
+  deleteNotificationGroup,
+  fetchNotifications,
 } = require("../controllers/notification.controller");
 const router = Router();
 
 router.get("/", checkAuth, fetchNotifications);
 router.delete("/", checkAuth, clearNotifications);
+router.delete("/groups/:groupId", checkAuth, deleteNotificationGroup);
 
 module.exports = router;


### PR DESCRIPTION
### This PR is trying to address the following issue: #9 

### PR content:
- Added a new endpoint `notifications/groups/:groupId` which allows us to remove group notification by group id
- We might was to consider not deleting the record but mark it as `read` or `deleted` for record keeping